### PR TITLE
Diffs for hda section files

### DIFF
--- a/api/utilities.py
+++ b/api/utilities.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
-from typing import TypeVar
+import difflib
+from typing import List, TypeVar
 
 K = TypeVar("K")
 V = TypeVar("V")
@@ -37,3 +38,25 @@ def get_ordered_dict_key_index(
         if key == target_key:
             return idx
     raise KeyError(f"'{target_key}' not found in the OrderedDict.")
+
+
+def file_diff(file_path_a: str, file_path_b: str) -> List[str]:
+    with open(file_path_a, "r") as file_a, open(file_path_b, "r") as file_b:
+        file_diff_list = [
+            i
+            for i in difflib.unified_diff(
+                file_a.readlines(), file_b.readlines(), lineterm=""
+            )
+        ]
+
+    return file_diff_list
+
+
+def string_diff(string_a: str, string_b: str) -> List[str]:
+    string_lines_a = string_a.splitlines()
+    string_lines_b = string_b.splitlines()
+    diff_list = [
+        i for i in difflib.unified_diff(string_lines_a, string_lines_b, lineterm="")
+    ]
+
+    return diff_list

--- a/test/api/test_hda_sections.py
+++ b/test/api/test_hda_sections.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+import unittest
+
+from api.hda_data import HdaData, HdaDefintion
+
+
+class TestHdaSections(unittest.TestCase):
+    def setUp(self):
+        hda_source_path = Path(
+            Path(__file__).parent.parent, "test_scenes/BoxHDA_source.hda"
+        ).as_posix()
+
+        hda_target_path = Path(
+            Path(__file__).parent.parent, "test_scenes/BoxHDA_edited.hda"
+        ).as_posix()
+
+        self.hda_source = HdaData(hda_source_path).latest_definition()
+        self.hda_target = HdaData(hda_target_path).latest_definition()
+
+    def test_provided_hda_diff(self):
+        expected_diff = {
+            "OnCreated": [
+                "--- ",
+                "+++ ",
+                "@@ -1 +1 @@",
+                '-print("oncreated")',
+                '+print("oncreaded")',
+            ],
+            "PythonModule": [
+                "--- ",
+                "+++ ",
+                "@@ -1,2 +1 @@",
+                ' print("module")',
+                '-print("yoyoyo")',
+            ],
+            "Help": [],
+            "Tools.shelf": [],
+        }
+        output_diff = HdaDefintion.diff_definition_sections(
+            self.hda_source, self.hda_target
+        )
+        self.assertEqual(output_diff, expected_diff)

--- a/ui/hip_file_diff_window.py
+++ b/ui/hip_file_diff_window.py
@@ -360,10 +360,10 @@ class HipFileDiffWindow(QMainWindow):
         # Assuming 'comparison_result' contains the differences,
         # we can now update our tree views based on the results.
         self.source_model.populate_with_data(
-            self.houdini_comparator.source_data, self.source_treeview.objectName()
+            self.houdini_comparator.source_nodes, self.source_treeview.objectName()
         )
         self.target_model.populate_with_data(
-            self.houdini_comparator.target_data, self.target_treeview.objectName()
+            self.houdini_comparator.target_nodes, self.target_treeview.objectName()
         )
 
         self.source_treeview.model().invalidateFilter()


### PR DESCRIPTION
Hey!

I did another pass so the diffs for sections of hda files are now stored and are ready to be displayed in some UI.

I've looked a bit into maybe converting the essentials of https://diff2html.xyz/ to python so one could output a .html file to be embedded in hda reviews (like on GH/GL), but I think it may be a **little** too involved.

But I think the output of difflib could be visualized quite well in Qt with medium amounts of effort, depending on potentially existing libraries.

Let me know if you have any comments or would like to see any changes.
Manuel