### PR TITLE
Add warning for unsupported files

### DIFF
--- a/ui/hip_file_diff_window.py
+++ b/ui/hip_file_diff_window.py
@@ -439,9 +439,15 @@ class HipFileDiffWindow(QMainWindow):
         self.target_treeview.item_dictionary = {}
         self.target_treeview.model().invalidateFilter()
 
-        if Path(source_path).suffix[1:] in HIP_FILE_FORMATS:
-            self.houdini_comparator = HipFileComparator(source_path, target_path)
+        if Path(source_path).suffix[1:] not in HIP_FILE_FORMATS:
+            QMessageBox.warning(
+                self,
+                "Unsupported file",
+                f"Please select valid .hip files to compare. Supported extensions: {', '.join(HIP_FILE_FORMATS)}",
+            )
+            return
 
+        self.houdini_comparator = HipFileComparator(source_path, target_path)
         self.houdini_comparator.compare()
 
         # Assuming 'comparison_result' contains the differences,


### PR DESCRIPTION
This should fix https://github.com/golubevcg/hip_file_diff_tool/issues/5:

Added a warning when comparing unsupported files:

![image](https://github.com/golubevcg/hip_file_diff_tool/assets/736361/c9d808fa-fda4-4eb9-812b-3975d0f7210e)
